### PR TITLE
数据插入本地表的hash策略改用murmur3_32,与官方murmurHash3_32保持一致，集群表分发策略使用murmurHash3…

### DIFF
--- a/src/main/java/com/glab/flink/connector/clickhouse/table/internal/partitioner/HashPartitioner.java
+++ b/src/main/java/com/glab/flink/connector/clickhouse/table/internal/partitioner/HashPartitioner.java
@@ -1,7 +1,12 @@
 package com.glab.flink.connector.clickhouse.table.internal.partitioner;
 
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.UnsignedInteger;
 import org.apache.flink.table.data.RowData;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 public class HashPartitioner implements ClickHousePartitioner {
@@ -13,7 +18,16 @@ public class HashPartitioner implements ClickHousePartitioner {
         this.getter = getter;
     }
 
+    //使用murmur3_32函数和clickhouse的murmurHash3_32保持统一
     public int select(RowData record, int numShards) {
-        return Math.abs(Objects.hashCode(this.getter.getFieldOrNull(record)) % numShards);
+
+        HashFunction hashFunction = Hashing.murmur3_32();
+        long hashCode = Long.valueOf(UnsignedInteger.valueOf(
+                Integer.toBinaryString(hashFunction.hashString(
+                        this.getter.getFieldOrNull(record).toString(), StandardCharsets.UTF_8).asInt())
+                , 2).toString());
+
+        return Math.abs((int)(hashCode % numShards));
+        // return Math.abs(Objects.hashCode(this.getter.getFieldOrNull(record)) % numShards);
     }
 }


### PR DESCRIPTION
…_32防止通过集群表补数据时数据错乱